### PR TITLE
Fix a crash and bump version

### DIFF
--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "me.ellenhp.aprstools"
         minSdkVersion 21
         targetSdkVersion 28
-        versionCode 7
-        versionName "0.1.5 beta"
+        versionCode 8
+        versionName "0.1.6 beta"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/mobile/src/main/java/me/ellenhp/aprstools/MapViewFragment.kt
+++ b/mobile/src/main/java/me/ellenhp/aprstools/MapViewFragment.kt
@@ -162,10 +162,11 @@ class MapViewFragment : Fragment(),
 
     private fun animateToLastLocation() {
         if (checkSelfPermission(activity!!, ACCESS_FINE_LOCATION) == PERMISSION_GRANTED ||
-                checkSelfPermission(activity!!, ACCESS_COARSE_LOCATION) == PERMISSION_GRANTED)
+                checkSelfPermission(activity!!, ACCESS_COARSE_LOCATION) == PERMISSION_GRANTED) {
             fusedLocationClient.get()?.lastLocation?.addOnSuccessListener(activity!!) {
-                map?.animateCamera(newLatLngZoom(LatLng(it.latitude, it.longitude), 10f))
+                it?.let { map?.animateCamera(newLatLngZoom(LatLng(it.latitude, it.longitude), 10f)) }
             }
+        }
     }
 
     /**


### PR DESCRIPTION
This crash involved the fused location provider not having any idea where the user is, and passing null to an onSuccess callback. Fixing it involved adding a null check.